### PR TITLE
Change sqlite3_errstr to sqlite3_errmsg

### DIFF
--- a/tools/hsbench/data_corpus.cpp
+++ b/tools/hsbench/data_corpus.cpp
@@ -110,7 +110,7 @@ vector<DataBlock> readCorpus(const string &filename) {
     if (status != SQLITE_DONE) {
         ostringstream oss;
         oss << "Error retrieving blocks from corpus: "
-            << sqlite3_errstr(status);
+            << sqlite3_errmsg(db);
 
         status = sqlite3_finalize(statement);
         assert(status == SQLITE_OK);


### PR DESCRIPTION
sqlite3_errstr was introduced in 3.7.15 (http://sqlite.org/changes.html)
which breaks build in redhat6 (sqlite3 ver 3.6.X)
and in line 77, sqlite3_errmsg is already used.