### PR TITLE
Functions for external memory management of scratch and stream objects

### DIFF
--- a/src/dispatcher.c
+++ b/src/dispatcher.c
@@ -87,11 +87,17 @@ CREATE_DISPATCH(hs_error_t, hs_free_database, hs_database_t *db);
 CREATE_DISPATCH(hs_error_t, hs_open_stream, const hs_database_t *db,
                 unsigned int flags, hs_stream_t **stream);
 
+CREATE_DISPATCH(hs_error_t, hs_open_stream_at, const hs_database_t *db,
+                unsigned int flags, hs_stream_t *stream);
+
 CREATE_DISPATCH(hs_error_t, hs_scan_stream, hs_stream_t *id, const char *data,
                 unsigned int length, unsigned int flags, hs_scratch_t *scratch,
                 match_event_handler onEvent, void *ctxt);
 
 CREATE_DISPATCH(hs_error_t, hs_close_stream, hs_stream_t *id,
+                hs_scratch_t *scratch, match_event_handler onEvent, void *ctxt);
+
+CREATE_DISPATCH(hs_error_t, hs_close_stream_nofree, hs_stream_t *id,
                 hs_scratch_t *scratch, match_event_handler onEvent, void *ctxt);
 
 CREATE_DISPATCH(hs_error_t, hs_scan_vector, const hs_database_t *db,

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -562,6 +562,34 @@ hs_error_t HS_CDECL hs_open_stream(const hs_database_t *db,
 }
 
 
+HS_PUBLIC_API
+hs_error_t HS_CDECL hs_open_stream_at(const hs_database_t *db,
+                                   UNUSED unsigned flags,
+                                   hs_stream_t *stream) {
+    if (unlikely(!stream)) {
+        return HS_INVALID;
+    }
+
+    hs_error_t err = validDatabase(db);
+    if (unlikely(err != HS_SUCCESS)) {
+        return err;
+    }
+
+    const struct RoseEngine *rose = hs_get_bytecode(db);
+    if (unlikely(!ISALIGNED_16(rose))) {
+        return HS_INVALID;
+    }
+
+    if (unlikely(rose->mode != HS_MODE_STREAM)) {
+        return HS_DB_MODE_ERROR;
+    }
+
+    init_stream(stream, rose, 1);
+
+    return HS_SUCCESS;
+}
+
+
 static really_inline
 void rawEodExec(hs_stream_t *id, hs_scratch_t *scratch) {
     const struct RoseEngine *rose = id->rose;
@@ -995,6 +1023,28 @@ hs_error_t HS_CDECL hs_close_stream(hs_stream_t *id, hs_scratch_t *scratch,
     }
 
     hs_stream_free(id);
+
+    return HS_SUCCESS;
+}
+
+HS_PUBLIC_API
+hs_error_t HS_CDECL hs_close_stream_nofree(hs_stream_t *id, hs_scratch_t *scratch,
+                                           match_event_handler onEvent,
+                                           void *context) {
+    if (!id) {
+        return HS_INVALID;
+    }
+
+    if (onEvent) {
+        if (!scratch || !validScratch(id->rose, scratch)) {
+            return HS_INVALID;
+        }
+        if (unlikely(markScratchInUse(scratch))) {
+            return HS_SCRATCH_IN_USE;
+        }
+        report_eod_matches(id, scratch, onEvent, context);
+        unmarkScratchInUse(scratch);
+    }
 
     return HS_SUCCESS;
 }

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -44,6 +44,9 @@
 #include "rose/rose_internal.h"
 #include "util/fatbit.h"
 
+#define SCRATCH_CACHE_ALIGN 64
+#define SCRATCH_ARRAY_BUF   256
+
 /**
  * Determine the space required for a correctly aligned array of fatbit
  * structure, laid out as:
@@ -88,7 +91,7 @@ hs_error_t alloc_scratch(const hs_scratch_t *proto, hs_scratch_t **scratch) {
     u32 som_attempted_size = proto->som_fatbit_size;
 
     struct hs_scratch *s;
-    struct hs_scratch *s_tmp;
+    struct hs_scratch *s_tmp = *scratch;
     size_t queue_size = queueCount * sizeof(struct mq);
     size_t qmpq_size = queueCount * sizeof(struct queue_match);
 
@@ -117,17 +120,21 @@ hs_error_t alloc_scratch(const hs_scratch_t *proto, hs_scratch_t **scratch) {
 
     /* the struct plus the allocated stuff plus padding for cacheline
      * alignment */
-    const size_t alloc_size = sizeof(struct hs_scratch) + size + 256;
-    s_tmp = hs_scratch_alloc(alloc_size);
-    hs_error_t err = hs_check_alloc(s_tmp);
-    if (err != HS_SUCCESS) {
-        hs_scratch_free(s_tmp);
-        *scratch = NULL;
-        return err;
+    const size_t alloc_size = sizeof(struct hs_scratch) + size +
+                              SCRATCH_CACHE_ALIGN + SCRATCH_ARRAY_BUF;
+
+    if (!s_tmp) {
+        s_tmp = hs_scratch_alloc(alloc_size);
+        hs_error_t err = hs_check_alloc(s_tmp);
+        if (err != HS_SUCCESS) {
+            hs_scratch_free(s_tmp);
+            *scratch = NULL;
+            return err;
+        }
     }
 
     memset(s_tmp, 0, alloc_size);
-    s = ROUNDUP_PTR(s_tmp, 64);
+    s = ROUNDUP_PTR(s_tmp, SCRATCH_CACHE_ALIGN);
     DEBUG_PRINTF("allocated %zu bytes at %p but realigning to %p\n", alloc_size, s_tmp, s);
     DEBUG_PRINTF("sizeof %zu\n", sizeof(struct hs_scratch));
     *s = *proto;
@@ -187,7 +194,7 @@ hs_error_t alloc_scratch(const hs_scratch_t *proto, hs_scratch_t **scratch) {
     s->tStateSize = tStateSize;
     current += tStateSize;
 
-    current = ROUNDUP_PTR(current, 64);
+    current = ROUNDUP_PTR(current, SCRATCH_CACHE_ALIGN);
 
     assert(ISALIGNED_N(current, 8));
     s->deduper.som_start_log[0] = (u64a *)current;
@@ -221,7 +228,7 @@ hs_error_t alloc_scratch(const hs_scratch_t *proto, hs_scratch_t **scratch) {
     s->som_attempted_set = (struct fatbit *)current;
     current += som_attempted_size;
 
-    current = ROUNDUP_PTR(current, 64);
+    current = ROUNDUP_PTR(current, SCRATCH_CACHE_ALIGN);
     assert(ISALIGNED_CL(current));
     s->fullState = (char *)current;
     s->fullStateSize = fullStateSize;
@@ -275,7 +282,8 @@ hs_error_t HS_CDECL hs_alloc_scratch(const hs_database_t *db,
     int resize = 0;
 
     hs_scratch_t *proto;
-    hs_scratch_t *proto_tmp = hs_scratch_alloc(sizeof(struct hs_scratch) + 256);
+    hs_scratch_t *proto_tmp = hs_scratch_alloc(sizeof(struct hs_scratch) +
+                                               SCRATCH_CACHE_ALIGN + SCRATCH_ARRAY_BUF);
     hs_error_t proto_ret = hs_check_alloc(proto_tmp);
     if (proto_ret != HS_SUCCESS) {
         hs_scratch_free(proto_tmp);
@@ -284,7 +292,7 @@ hs_error_t HS_CDECL hs_alloc_scratch(const hs_database_t *db,
         return proto_ret;
     }
 
-    proto = ROUNDUP_PTR(proto_tmp, 64);
+    proto = ROUNDUP_PTR(proto_tmp, SCRATCH_CACHE_ALIGN);
 
     if (*scratch) {
         *proto = **scratch;
@@ -369,6 +377,7 @@ hs_error_t HS_CDECL hs_alloc_scratch(const hs_database_t *db,
     if (resize) {
         if (*scratch) {
             hs_scratch_free((*scratch)->scratch_alloc);
+            *scratch = NULL;
         }
 
         hs_error_t alloc_ret = alloc_scratch(proto, scratch);
@@ -394,6 +403,24 @@ hs_error_t HS_CDECL hs_clone_scratch(const hs_scratch_t *src,
     }
 
     *dest = NULL;
+    hs_error_t ret = alloc_scratch(src, dest);
+    if (ret != HS_SUCCESS) {
+        *dest = NULL;
+        return ret;
+    }
+
+    assert(!(*dest)->in_use);
+    return HS_SUCCESS;
+}
+
+HS_PUBLIC_API
+hs_error_t HS_CDECL hs_clone_scratch_at(const hs_scratch_t *src,
+                                        hs_scratch_t **dest) {
+    if (!dest || !*dest || !src ||
+        !ISALIGNED_CL(src) || src->magic != SCRATCH_MAGIC) {
+        return HS_INVALID;
+    }
+
     hs_error_t ret = alloc_scratch(src, dest);
     if (ret != HS_SUCCESS) {
         *dest = NULL;
@@ -439,3 +466,17 @@ hs_error_t HS_CDECL hs_scratch_size(const hs_scratch_t *scratch, size_t *size) {
 
     return HS_SUCCESS;
 }
+
+HS_PUBLIC_API
+hs_error_t HS_CDECL hs_scratch_memaddr(const hs_scratch_t *scratch, char **memaddr) {
+    if (!memaddr || !scratch || !ISALIGNED_CL(scratch) ||
+        scratch->magic != SCRATCH_MAGIC) {
+        return HS_INVALID;
+    }
+
+    assert(scratch->scratch_alloc);
+    *memaddr = scratch->scratch_alloc;
+
+    return HS_SUCCESS;
+}
+

--- a/unit/hyperscan/single.cpp
+++ b/unit/hyperscan/single.cpp
@@ -214,9 +214,26 @@ protected:
         ASSERT_EQ(HS_SUCCESS, err);
         EXPECT_TRUE(cloned != nullptr);
 
-        err = hs_free_scratch(scratch);
-        EXPECT_EQ(HS_SUCCESS, err);
         err = hs_free_scratch(cloned);
+        EXPECT_EQ(HS_SUCCESS, err);
+        cloned = NULL;
+
+        // Try cloning with external allocation
+        size_t clone_size;
+        err = hs_scratch_size(scratch, &clone_size);
+        EXPECT_EQ(HS_SUCCESS, err);
+        char* clone_buffer = new char[clone_size];
+        cloned = (hs_scratch_t*)clone_buffer;
+        err = hs_clone_scratch_at(scratch, &cloned);
+        EXPECT_EQ(HS_SUCCESS, err);
+        EXPECT_TRUE(cloned != nullptr);
+        char* clone_buffer2 = NULL;
+        err = hs_scratch_memaddr(cloned, &clone_buffer2);
+        EXPECT_TRUE(clone_buffer2 != nullptr);
+        EXPECT_TRUE(clone_buffer2 == clone_buffer);
+        delete [] clone_buffer2;
+
+        err = hs_free_scratch(scratch);
         EXPECT_EQ(HS_SUCCESS, err);
     }
 


### PR DESCRIPTION
Pull request for a simple set of features that make it easy for external memory management of the scratch and stream objects without going through the four static memory allocators.  This is essential for high performance in NUMA (Non-Uniform Memory Architecture) systems such as Linux.  Also addressed a corner case where scratch objects may be shorted when cache aligned.