### PR TITLE
Fix hscollider build on alpine linux

### DIFF
--- a/tools/hscollider/sig.cpp
+++ b/tools/hscollider/sig.cpp
@@ -36,13 +36,15 @@
 #include <ctype.h>
 #include <string>
 
-#if defined(HAVE_SIGACTION) || defined(_WIN32)
+#if defined(_WIN32)
 #include <signal.h>
+#elif defined(HAVE_SIGACTION)
+#include <signal.h>
+#include <unistd.h>
 #endif
 
 #ifdef HAVE_BACKTRACE
 #include <execinfo.h>
-#include <unistd.h>
 #endif
 
 #define BACKTRACE_BUFFER_SIZE 200


### PR DESCRIPTION
_exit() is defined in <unistd.h> as per POSIX.

I don't have access to a Windows box so can't test the build on that platform.