### PR TITLE
cmake/boost.cmake: fixes search path for (linked) boost package if build in sub-directory

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -13,15 +13,19 @@ set(BOOST_NO_BOOST_CMAKE ON)
 
 unset(Boost_INCLUDE_DIR CACHE)
 # we might have boost in tree, so provide a hint and try again
-set(BOOST_INCLUDEDIR "${PROJECT_SOURCE_DIR}/include")
+set(BOOST_INCLUDEDIR "${PROJECT_SOURCE_DIR}/include/boost")
 find_package(Boost ${BOOST_MINVERSION} QUIET)
 if(NOT Boost_FOUND)
+  set(BOOST_INCLUDEDIR "${PROJECT_SOURCE_DIR}/include")
+  find_package(Boost ${BOOST_MINVERSION} QUIET)
+  if(NOT Boost_FOUND)
     # otherwise check for Boost installed on the system
     unset(BOOST_INCLUDEDIR)
     find_package(Boost ${BOOST_MINVERSION} QUIET)
     if(NOT Boost_FOUND)
         message(FATAL_ERROR "Boost ${BOOST_MINVERSION} or later not found. Either install system packages if available, extract Boost headers to ${CMAKE_SOURCE_DIR}/include, or set the CMake BOOST_ROOT variable.")
     endif()
+  endif()
 endif()
 
 message(STATUS "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")


### PR DESCRIPTION
### Rationales

If one try to build hyperscan in a sub-directory, and boost is linked to include, as it is described in [Getting started](http://intel.github.io/hyperscan/dev-reference/getting_started.html), one may get an error that boost package is not found:
```bash
$ cd /path/to/hyperscan
$ ln -s /path/to/boost ./include/boost
$ mkdir build/Release_x64; cd build/Release_x64
$ cmake -S ../.. -B .
...
CMake Error at cmake/boost.cmake:23 (message):
  Boost 1.57.0 or later not found.  Either install system packages if
  available, extract Boost headers to /path/to/hyperscan/include, or
  set the CMake BOOST_ROOT variable.
...
-- Configuring incomplete, errors occurred!
```
Note: it seems to be affected only if one uses cmake not in project root directory... for instance like devs doing it often to hold Debug/Release/etc and platforms related (x64/x86) builds in different locations.

This PR proposes a fix for that - it would take a look into `include/boost` before `include`.

### Toolchain and platform details
```bash
$ cmake --version
cmake version 3.20.1

$ grep 'Boost VERSION' ../../include/boost/CMakeLists.txt
project(Boost VERSION 1.78.0 LANGUAGES CXX)

$ bash --version
GNU bash, version 5.1.8(1)-release (x86_64-pc-msys)

$ systeminfo | grep 'OS '
OS Name:                   Microsoft Windows 10 Pro
OS Version:                10.0.19042 N/A Build 19042
```