### PR TITLE
use 64bit find-and-clear avoiding build failure with GCC14/i386

### DIFF
--- a/src/nfa/limex_exceptional.h
+++ b/src/nfa/limex_exceptional.h
@@ -246,7 +246,7 @@ int PE_FN(STATE_ARG, ESTATE_ARG, UNUSED u32 diffmask, STATE_T *succ,
         u64a word = eq512mask(emask, load_m512(&limex->exceptionBitMask));
 
         do {
-            u32 bit = FIND_AND_CLEAR_FN(&word);
+            u32 bit = findAndClearLSB_64(&word);
             const EXCEPTION_T *e = &exceptions[bit];
 
             if (!RUN_EXCEPTION_FN(e, STATE_ARG_NAME, succ,


### PR DESCRIPTION
Rebuilding the Debian package with GCC 14 for the i386 architecture exposes an "incompatible pointer" error, cf. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091572

`limex_exceptional.h` defines a `FIND_AND_CLEAR_FN` macro that is used on `CHUNK_T` pointers in most cases, except in https://github.com/intel/hyperscan/blob/bc3b191ab56055e8560c7cdc161c289c4d76e3d2/src/nfa/limex_exceptional.h#L249 I'm pretty sure that I should not change `word` from an `u64a` to a `CHUNK_T` at this point but rather use the 64bit-specific find-and-clear function as done in the patch.

This fixes the build failure, but I am not sure if this is correct. Please advise on how to test this. Are there any test cases fthat stress this specific code?