### PR TITLE
Pass `nm` and `objcopy` as optional environment variables to `build_wrapper`

### DIFF
--- a/cmake/build_wrapper.sh
+++ b/cmake/build_wrapper.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -e
 # This is used for renaming symbols for the fat runtime, don't call directly
 # TODO: make this a lot less fragile!
+
+NM=${NM_PATH:-nm}
+OBJCOPY=${OBJCOPY_PATH:-objcopy}
+
 cleanup () {
     rm -f ${SYMSFILE} ${KEEPSYMS}
 }
@@ -10,6 +14,7 @@ KEEPSYMS_IN=$2
 shift 2
 # $@ contains the actual build command
 OUT=$(echo "$@" | rev | cut -d ' ' -f 2- | rev | sed 's/.* -o \(.*\.o\).*/\1/')
+
 trap cleanup INT QUIT EXIT
 SYMSFILE=$(mktemp -p /tmp ${PREFIX}_rename.syms.XXXXX)
 KEEPSYMS=$(mktemp -p /tmp keep.syms.XXXXX)
@@ -17,12 +22,12 @@ KEEPSYMS=$(mktemp -p /tmp keep.syms.XXXXX)
 LIBC_SO=$("$@" --print-file-name=libc.so.6)
 cp ${KEEPSYMS_IN} ${KEEPSYMS}
 # get all symbols from libc and turn them into patterns
-nm -f p -g -D ${LIBC_SO} | sed -s 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
+${NM} -f p -g -D ${LIBC_SO} | sed -s 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
 # build the object
 "$@"
 # rename the symbols in the object
-nm -f p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
+${NM} -f p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
 if test -s ${SYMSFILE}
 then
-    objcopy --redefine-syms=${SYMSFILE} ${OUT}
+    ${OBJCOPY} --redefine-syms=${SYMSFILE} ${OUT}
 fi


### PR DESCRIPTION
When cross-compiling Hyperscan with fat runtime enabled, the build system previously defaulted to the native objcopy and nm tools. This could lead to architecture mismatches, since the native tools might not match the target architecture produced by the cross-compiler.

This PR introduces an enhancement that allows users to specify alternative `objcopy` and `nm` executables by passing them as environment variables (`OBJCOPY_PATH` and `NM_PATH`). With these variables, the build system uses the toolchain-specific versions of these utilities, ensuring that symbol renaming is performed correctly for the target architecture.