### PR TITLE
Add Zapier integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1426,3 +1426,5 @@ option(BUILD_EXAMPLES "Build Hyperscan example code (default TRUE)" TRUE)
 if(NOT WIN32 AND BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
+
+add_subdirectory(zapier)

--- a/README.md
+++ b/README.md
@@ -41,3 +41,35 @@ sending email to the list, or by creating an issue on Github.
 If you wish to contact the Hyperscan team at Intel directly, without posting
 publicly to the mailing list, send email to
 [hyperscan@intel.com](mailto:hyperscan@intel.com).
+
+# Zapier Integration
+
+To integrate Hyperscan with the Zapier platform, follow these steps:
+
+1. Ensure you have the `requests` library installed. You can install it using pip:
+   ```
+   pip install requests
+   ```
+
+2. Use the functions provided in the `zapier/zapier_integration.py` file to handle triggers and actions for Zapier. For example:
+   ```python
+   from zapier.zapier_integration import trigger_event, action_create_item, action_update_item, action_delete_item
+
+   # Trigger an event
+   response = trigger_event("event_name", {"key": "value"})
+   print(response)
+
+   # Create an item
+   response = action_create_item("item_name", {"key": "value"})
+   print(response)
+
+   # Update an item
+   response = action_update_item("item_id", {"key": "value"})
+   print(response)
+
+   # Delete an item
+   response = action_delete_item("item_id")
+   print(response)
+   ```
+
+3. Refer to the `zapier/zapier_integration.py` file for more details on the available functions and their usage.

--- a/unit/zapier_integration_tests.cpp
+++ b/unit/zapier_integration_tests.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <zapier/zapier_integration.py>
+
+using namespace testing;
+
+class ZapierIntegrationTest : public Test {
+protected:
+    void SetUp() override {
+        // Set up any necessary preconditions for the tests
+    }
+
+    void TearDown() override {
+        // Clean up any resources used by the tests
+    }
+};
+
+TEST_F(ZapierIntegrationTest, TriggerEvent) {
+    // Mock the requests.post function
+    MockFunction<requests::post> mock_post;
+    EXPECT_CALL(mock_post, Call(_, _))
+        .WillOnce(Return(MockResponse(200, R"({"status": "success"})")));
+
+    // Call the trigger_event function
+    auto response = trigger_event("test_event", {{"key", "value"}});
+
+    // Verify the response
+    EXPECT_EQ(response["status"], "success");
+}
+
+TEST_F(ZapierIntegrationTest, ActionCreateItem) {
+    // Mock the requests.post function
+    MockFunction<requests::post> mock_post;
+    EXPECT_CALL(mock_post, Call(_, _))
+        .WillOnce(Return(MockResponse(200, R"({"status": "success"})")));
+
+    // Call the action_create_item function
+    auto response = action_create_item("test_item", {{"key", "value"}});
+
+    // Verify the response
+    EXPECT_EQ(response["status"], "success");
+}
+
+TEST_F(ZapierIntegrationTest, ActionUpdateItem) {
+    // Mock the requests.post function
+    MockFunction<requests::post> mock_post;
+    EXPECT_CALL(mock_post, Call(_, _))
+        .WillOnce(Return(MockResponse(200, R"({"status": "success"})")));
+
+    // Call the action_update_item function
+    auto response = action_update_item("test_item_id", {{"key", "value"}});
+
+    // Verify the response
+    EXPECT_EQ(response["status"], "success");
+}
+
+TEST_F(ZapierIntegrationTest, ActionDeleteItem) {
+    // Mock the requests.post function
+    MockFunction<requests::post> mock_post;
+    EXPECT_CALL(mock_post, Call(_, _))
+        .WillOnce(Return(MockResponse(200, R"({"status": "success"})")));
+
+    // Call the action_delete_item function
+    auto response = action_delete_item("test_item_id");
+
+    // Verify the response
+    EXPECT_EQ(response["status"], "success");
+}

--- a/zapier/zapier_integration.py
+++ b/zapier/zapier_integration.py
@@ -1,0 +1,41 @@
+import requests
+
+ZAPIER_WEBHOOK_URL = "https://hooks.zapier.com/hooks/catch/123456/abcdef/"
+
+def trigger_event(event_name, data):
+    payload = {
+        "event": event_name,
+        "data": data
+    }
+    response = requests.post(ZAPIER_WEBHOOK_URL, json=payload)
+    response.raise_for_status()
+    return response.json()
+
+def action_create_item(item_name, item_data):
+    payload = {
+        "action": "create_item",
+        "item_name": item_name,
+        "item_data": item_data
+    }
+    response = requests.post(ZAPIER_WEBHOOK_URL, json=payload)
+    response.raise_for_status()
+    return response.json()
+
+def action_update_item(item_id, item_data):
+    payload = {
+        "action": "update_item",
+        "item_id": item_id,
+        "item_data": item_data
+    }
+    response = requests.post(ZAPIER_WEBHOOK_URL, json=payload)
+    response.raise_for_status()
+    return response.json()
+
+def action_delete_item(item_id):
+    payload = {
+        "action": "delete_item",
+        "item_id": item_id
+    }
+    response = requests.post(ZAPIER_WEBHOOK_URL, json=payload)
+    response.raise_for_status()
+    return response.json()


### PR DESCRIPTION
Add Zapier integration to Hyperscan repository.

* **New Directory and File**: Create a new directory `zapier` and add `zapier_integration.py` to handle integration logic with the Zapier platform.
* **CMake Configuration**: Update `CMakeLists.txt` to include the new `zapier` directory in the build process.
* **Documentation**: Update `README.md` to include instructions on how to use the Zapier integration.
* **Unit Tests**: Add `unit/zapier_integration_tests.cpp` to create unit tests for the Zapier integration using the Google Test framework.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/intel/hyperscan/pull/450?shareId=d88e6db8-814f-480d-a13c-f628848ee4b6).