### PR TITLE
Make build_wrapper.sh a bit more robust and support LLVM toolchain

### DIFF
--- a/cmake/build_wrapper.sh
+++ b/cmake/build_wrapper.sh
@@ -1,9 +1,15 @@
 #!/bin/sh -e
 # This is used for renaming symbols for the fat runtime, don't call directly
 # TODO: make this a lot less fragile!
+
+set -e
+
 cleanup () {
     rm -f ${SYMSFILE} ${KEEPSYMS}
 }
+
+: ${NM:=nm}
+: ${OBJCOPY:=objcopy}
 
 PREFIX=$1
 KEEPSYMS_IN=$2
@@ -17,12 +23,12 @@ KEEPSYMS=$(mktemp -p /tmp keep.syms.XXXXX)
 LIBC_SO=$("$@" --print-file-name=libc.so.6)
 cp ${KEEPSYMS_IN} ${KEEPSYMS}
 # get all symbols from libc and turn them into patterns
-nm -f p -g -D ${LIBC_SO} | sed -s 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
+${NM} -f posix -g -D ${LIBC_SO} | sed -s 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
 # build the object
 "$@"
 # rename the symbols in the object
-nm -f p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
+${NM} -f posix -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
 if test -s ${SYMSFILE}
 then
-    objcopy --redefine-syms=${SYMSFILE} ${OUT}
+    ${OBJCOPY} --redefine-syms=${SYMSFILE} ${OUT}
 fi


### PR DESCRIPTION
There is a minor problem with the current version of the script - it can fail silently resulting into linker errors down the line when linking against built hyperscan library.

How could it happen?

If I only have llvm toolchain in the system, my nm and objcopy tools are likely to be called llvm-nm and llvm-objcopy and not nm and objcopy. When that happens, build_wraper.sh will try to call nm to produce SYMSFILE.

Naturally, because nm does not exist in the system it will fail, but it's not the last command of the script, so the script will continue it's execution.

In the end of the script we have an if statement that checks if SYMSFILE exists and not empty. In our case, the file would exist, but would be empty, so objcopy in the if body will never get called and the script will finish execution with a successful status, thus failing silently.

When building fat runtime, it basically will result in a library that is missing a bunch of symbol definitions needed by the dispatcher code.

To make the failure a little bit more explicit I added `set -e`, this way the script will fail on the first command failure in the script making the issue explicit.

Additionally, given the scenario I described above, I changed the script a little bit to allow overwriting the nm and objcopy tools used in the script via environment variables.

By default, when environment variables are not provided we still fallback to the default nm and objcopy tools, so it should not affect anybody who relies on the current behavior.

One last change, GNU nm tools for the format flag (-f) only looks at the first letter of the format, so for example when you provide posix there as the flag value it's the same as just providing p as a value.

However, LLVM version of nm is a bit more strict and does not recognize p as a valid value. Given, that both tools accept posix as a value, but p is not accepted by LLVM tools, I changed the script to spell out posix value - this should work for both GNU (and any toolchain built on top of GNU codebase) and LLVM.

Testing:

I did build hyperscan with both default nm and objcopy as well as LLVM versions provided via environment variables.
I run unit tests for both bulds, in both cases tests passed.

And I did verify that if the build_wrapper.sh tries to use nm or objcopy binrary that does not exist, the script fails explicitly and the build fails with it.