### PR TITLE
Fix assertion failure for bounded repeat of exactly MAX_REPEAT

### DIFF
--- a/src/parser/ComponentRepeat.cpp
+++ b/src/parser/ComponentRepeat.cpp
@@ -122,7 +122,7 @@ void checkPositions(vector<PositionInfo> &v, const GlushkovBuildState &bs) {
 
 void ComponentRepeat::notePositions(GlushkovBuildState &bs) {
     assert(m_max > 0);
-    assert(m_max == NoLimit || m_max < MAX_REPEAT);
+    assert(m_max == NoLimit || m_max <= MAX_REPEAT);
 
     /* Note: We can construct smaller subgraphs if we're not maintaining edge
      * priorities. */


### PR DESCRIPTION
## Summary

Fixes an assertion failure (crash) when compiling a pattern with a bounded repeat of exactly 32767 (`MAX_REPEAT`).

The constructor in `ComponentRepeat` validates with `m_max > MAX_REPEAT`, correctly allowing 32767 as a valid value. However, the assertion in `notePositions()` uses `m_max < MAX_REPEAT`, which rejects 32767 and triggers an abort.

Fixes #425

## Reproduction

```python
import hyperscan
db = hyperscan.Database(mode=hyperscan.HS_MODE_STREAM)
db.compile(expressions=[b'abc .{0,32767}'])  # assertion failure / crash
```

- `{0,32766}` compiles successfully
- `{0,32768}` returns a proper "Bounded repeat is too large" error
- `{0,32767}` crashes with: `Assertion 'm_max == NoLimit || m_max < MAX_REPEAT' failed`

## Change

One-character fix in `src/parser/ComponentRepeat.cpp`:

```diff
-    assert(m_max == NoLimit || m_max < MAX_REPEAT);
+    assert(m_max == NoLimit || m_max <= MAX_REPEAT);
```

This makes the assertion consistent with the constructor's boundary validation on lines 71-76 of the same file.
